### PR TITLE
improved upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ $(TMPDIR)/$(PROJNAME).bin: $(TMPDIR)/$(PROJNAME).elf
 #upload to the arduino by first resetting it (stty) and the running bossac
 upload: $(TMPDIR)/$(PROJNAME).bin
 	stty -F $(PORT) cs8 1200 hupcl
+	sleep 1
 	$(ADIR)/tools/bossac -U false -e -w $(VERIFY) -b $(TMPDIR)/$(PROJNAME).bin -R
 
 #to view the serial port with screen.


### PR DESCRIPTION
bossac often complains about "Auto scan for device failed". Adding a sleep between stty and bossac solves the problem most of the times.
